### PR TITLE
Fix compilation on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ find_package(OpenMVG REQUIRED)
 find_package(Eigen3 REQUIRED NO_MODULE)
 find_package(OpenMP REQUIRED)
 
+if (OPENMP_FOUND)
+    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
 add_library(pwmvs
     src/fusion.cpp
     src/pwmvs.cpp
@@ -27,10 +33,7 @@ target_link_libraries(pwmvs
         OpenMVG::openMVG_sfm
         OpenMVG::openMVG_image
         OpenMVG::openMVG_features
-        Eigen3::Eigen
-    PRIVATE
-        OpenMP::OpenMP_CXX
-)
+        Eigen3::Eigen)
 target_compile_features(pwmvs
     PUBLIC
         cxx_generic_lambdas

--- a/include/image_io.hpp
+++ b/include/image_io.hpp
@@ -140,7 +140,7 @@ static void TransformImage(
     {
         for (int col = 0; col < image_out.Width(); ++col)
         {
-            const Vector2 x = convertToFloat(Vector2i(col, row))
+            const Vector2 x = convertToFloat(Vector2i(col, row));
             const Vector2 x_ = cam_in->cam2ima(cam_in->add_disto(cam_out->remove_disto(cam_out->ima2cam(x.cast<double>())))).cast<FloatT>();
 
             // pick pixel if it is in the image domain


### PR DESCRIPTION
HI, 

this patch aims at fixing compilation on osx. 

- The first one is a missing semi column 
- The second one is a replacement of OpenMP::OpenMP_CXX. I know this is an ugly fix but at this time, it is still the most portable way to deal with OpenMP (up to date cmake does not link correctly with libomp with the OpenMP::OpenMP_CXX flag on macOS)